### PR TITLE
Issues can also be closed by resolve(|s|d)

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ https://github.com/rails/rails/blob/master/activemodel/lib/active_model.rb#L53-L
 ![Line Highlighting](http://i.imgur.com/8AhjrCz.png)
 
 ### Closing Issues via Commit Messages
-If a particular commit fixes an issue, any of the keywords `fix/fixes/fixed` or `close/closes/closed`, followed by the issue number, will close the issue once it is committed to the master branch.
+If a particular commit fixes an issue, any of the keywords `fix/fixes/fixed`, `close/closes/closed` or `resolve/resolves/resolved`, followed by the issue number, will close the issue once it is committed to the master branch.
 
 ```bash
 $ git commit -m "Fix cock up, fixes #12"


### PR DESCRIPTION
As documented in https://help.github.com/articles/closing-issues-via-commit-messages (to which the section links on the end!).  resolve\* was not there from the very beginning, though — and thus many people (get off my lawn!) don’t know about it.
