### PR TITLE
Fix the URL for checking out a PR to FETCH_HEAD

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -568,7 +568,7 @@ $ git stripspace < README.md
 特定のプルリクエストを取り込み、一時的に`FETCH_HEAD`として保存すると、素早く差分を確認してマージすることが可能だ:
 
 ```bash
-$ git fetch origin refs/pull/[PR-Number]
+$ git fetch origin refs/pull/[PR-Number]/head
 ```
 
 参照仕様を使うとすべてのプルリクエストをローカル・ブランチとして取り込むことができる:

--- a/README.ko.md
+++ b/README.ko.md
@@ -624,7 +624,7 @@ $ git stripspace < README.md
 가져오려면 이렇게 합니다.
 
 ```bash
-$ git fetch origin refs/pull/[PR-Number]
+$ git fetch origin refs/pull/[PR-Number]/head
 ```
 
 모든 풀 리퀘스트 브랜치를 refspec에 의한 로컬 리모트 브랜치로 받을 수도

--- a/README.md
+++ b/README.md
@@ -573,7 +573,7 @@ Pull Requests are special branches on the GitHub repository which can be retriev
 Retrieve a specific Pull Request and store it temporarily in `FETCH_HEAD` for quickly `diff`ing or `merge`ing:
 
 ```bash
-$ git fetch origin refs/pull/[PR-Number]
+$ git fetch origin refs/pull/[PR-Number]/head
 ```
 
 Acquire all Pull Request branches as local remote branches by refspec:

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -524,7 +524,7 @@ Pull Request是一种GitHub上可以通过以下多种方式在本地被检索�
 检索某个分支并临时储存在本地的`FETCH_HEAD`中以便快速查看更改(diff)以及合并(merge)：
 
 ```bash
-$ git fetch origin refs/pull/[PR-Number]
+$ git fetch origin refs/pull/[PR-Number]/head
 ```
 
 通过refspec获取所有的Pull Request为本地分支：


### PR DESCRIPTION
I'm pretty sure this example if missing `/head` on the end, because when
I do this it fails:

```
$ git fetch origin refs/pull/70
fatal: Couldn't find remote ref refs/pull/70
fatal: The remote end hung up unexpectedly
```

Whereas when I do this it works:

```
$ git fetch origin refs/pull/70/head
From github.internal:organisation/example-repo
 * branch            refs/pull/70/head -> FETCH_HEAD
```
