### PR TITLE
Minor Edit for Images/GIFs section

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,12 @@ Images and GIFs can be added to comments, READMEs etc.:
 ![Alt Text](http://www.sheawong.com/wp-content/uploads/2013/08/keephatin.gif)
 ```
 
+Raw images from the repo can be used by calling them directly.:
+
+```
+![Alt Text](https://github.com/(user)/(repo)/raw/master/path/to/image.gif)
+```
+
 ![Peter don't care](http://www.sheawong.com/wp-content/uploads/2013/08/keephatin.gif)
 
 All images are cached on GitHub, so if your host goes down, the image will remain available.
@@ -355,13 +361,6 @@ There are multiple ways of embedding images in Wiki pages. There's the standard 
 Which produces:
 
 ![Just a screenshot](http://i.imgur.com/J5bMf7S.png)
-
-#### Using Raw GitHub Images
-Raw images from the repo can be used by calling them directly.:
-
-```
-![Alt Text](https://github.com/(user)/(repo)/raw/master/path/to/image.gif)
-```
 
 ### Quick Quoting
 When on a comment thread and you want to quote something someone previously said, highlight the text and press `r`, this will copy it into your text box in the block-quote format.


### PR DESCRIPTION
This is just a minor addition to the Images/GIFs section of the GitHub Cheat Sheet giving an example of using raw images from the repository for README.md and Wiki pages.

It might just be me but I have found myself needing this several times but finding it referenced and explained has always been a challenge. I just thought adding it to the GitHub Cheat Sheet would be useful to myself and others.
