### PR TITLE
Add chrome only disclaimer

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,9 @@ When on a comment thread and you want to quote something someone previously said
 [*Read more about quick quoting.*](https://github.com/blog/1399-quick-quotes)
 
 ### Pasting Clipboard Image to Comments
+
+_(Works on Chrome browsers only)_
+
 After taking a screenshot and adding it to the clipboard (mac: `cmd-ctrl-shift-4`), you can simply paste (`cmd-v / ctrl-v`) the image into the comment section and it will be auto-uploaded to github.
 
 ![Pasting Clipboard Image to Comments](https://cloud.githubusercontent.com/assets/39191/5794265/39c9b65a-9f1b-11e4-9bc7-04e41f59ea5f.png)


### PR DESCRIPTION
The pasting of images from clipboard is chrome only, It is stated in the _read more_ article but anyone who doesn't _read more_ may become confused (like I did).