### PR TITLE
Fix date format in Comparing Branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ https://github.com/rails/rails/compare/master@{1.day.ago}...master
 https://github.com/rails/rails/compare/master@{2014-10-04}...master
 ```
 
-*Dates are in the format `YYYY-DD-MM`*
+*Dates are in the format `YYYY-MM-DD`*
 
 ![Another compare example](http://i.imgur.com/5dtzESz.png)
 


### PR DESCRIPTION
This format is mentioned in https://help.github.com/articles/comparing-commits-across-time/#comparisons-across-time.
Manual tests may be confusing because matched commits has date out of chosen range: this happens because github select commits using their merge date, not commit date.
