### PR TITLE
Adding education.github.com to github resource list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -612,6 +612,7 @@ GitHubs icons (Octicons) have now been open sourced.
 | GitHub Help | https://help.github.com/ |
 | GitHub Training | https://training.github.com/ |
 | GitHub Developer | https://developer.github.com/ |
+| Github Education (Free Micro Account and other stuff for students) | https://education.github.com/ |
 
 #### GitHub Talks
 | Title | Link |


### PR DESCRIPTION
I've added education.github.com to the github resource list.

As a student you can apply there for a free github micro account and various other discounts.
https://education.github.com/pack

I don't think many people know about this and that's why I'd like to add this to the list.