### PR TITLE
Update introduction translation(ko)

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -4,7 +4,7 @@ Git과 Github에서 꽤 유용하지만 숨겨져 있는 기능들에 대해 다
 
 *단축주소: [`http://git.io/sheet`](http://git.io/sheet)*
 
-*다른 언어로 보기: [English](README.md), [한국어](README.ko.md), [日本語](README.ja.md), [简体中文](README.zh-cn.md), [正體中文](README.zh-tw.md).*
+*Read this in other languages: [English](README.md), [한국어](README.ko.md), [日本語](README.ja.md), [简体中文](README.zh-cn.md), [正體中文](README.zh-tw.md).*
 
 # 목록
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,10 +1,10 @@
-# 깃허브 치트 시트 [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
+# Github 치트 시트 [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
 
-A collection of cool hidden and not so hidden features of Git and GitHub. This cheat sheet was inspired by [Zach Holman](https://github.com/holman)'s [Git and GitHub Secrets](http://www.confreaks.com/videos/1229-aloharuby2012-git-and-github-secrets) talk at Aloha Ruby Conference 2012 ([slides](https://speakerdeck.com/holman/git-and-github-secrets)) and his [More Git and GitHub Secrets](https://vimeo.com/72955426) talk at WDCNZ 2013 ([slides](https://speakerdeck.com/holman/more-git-and-github-secrets)).
+Git과 Github에서 꽤 유용하지만 숨겨져 있는 기능들에 대해 다룹니다. 이 치트 시트는 [Zach Holman](https://github.com/holman)이 Aloha Ruby Conference 2012에서 발표한 [Git과 GitHub의 비밀들](http://www.confreaks.com/videos/1229-aloharuby2012-git-and-github-secrets)의  ([슬라이드](https://speakerdeck.com/holman/git-and-github-secrets))와 WDCNZ 2013에서 발표한 [Git과 Github에 대한 더 많은 비밀들](https://vimeo.com/72955426)의 ([슬라이드](https://speakerdeck.com/holman/more-git-and-github-secrets))에서 영감을 받아 작성되었습니다.
 
-*Shortlink: [`http://git.io/sheet`](http://git.io/sheet)*
+*단축주소: [`http://git.io/sheet`](http://git.io/sheet)*
 
-*Read this in other languages: [English](README.md), [한국어](README.ko.md), [日本語](README.ja.md), [简体中文](README.zh-cn.md), [正體中文](README.zh-tw.md).*
+*다른 언어로 보기: [English](README.md), [한국어](README.ko.md), [日本語](README.ja.md), [简体中文](README.zh-cn.md), [正體中文](README.zh-tw.md).*
 
 # 목록
 


### PR DESCRIPTION
Translate introduction to Korean.

...and, Github is a proper noun, so I changed 깃허브 to Github.
Maybe It'll be more legible.