### PR TITLE
Move SSH keys section into GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,11 @@ A collection of cool hidden and not so hidden features of Git and GitHub. This c
   - [GitHub Student Developer Pack](#github-student-developer-pack)
   - [GitHub Resources](#github-resources)
     - [GitHub Talks](#github-talks)
+  - [SSH keys](#ssh-keys)
  - [Git](#git)
   - [Remove All Deleted Files from the Working Tree](#remove-all-deleted-files-from-the-working-tree)
   - [Previous Branch](#previous-branch)
   - [Stripspace](#stripspace)
-  - [SSH keys](#ssh-keys)
   - [Checking out Pull Requests](#checking-out-pull-requests)
   - [Empty Commits](#empty-commits)
   - [Styled Git Status](#styled-git-status)
@@ -656,6 +656,18 @@ If you are a student you will be eligible for the GitHub Student Developer Pack.
 | Git and GitHub Secrets | https://www.youtube.com/watch?v=Foz9yvMkvlA |
 | More Git and GitHub Secrets | https://www.youtube.com/watch?v=p50xsL-iVgU |
 
+### SSH keys
+
+You can get a list of public ssh keys in plain text format by visiting:
+
+```
+https://github.com/{user}.keys
+```
+
+e.g. [https://github.com/tiimgreen.keys](https://github.com/tiimgreen.keys)
+
+[*Read more about accessing public ssh keys.*](https://changelog.com/github-exposes-public-ssh-keys-for-its-users/)
+
 ## Git
 ### Remove All Deleted Files from the Working Tree
 When you delete a lot of files using `/bin/rm` you can use the following command to remove them from the working tree and from the index, eliminating the need to remove each one individually:
@@ -714,18 +726,6 @@ $ git stripspace < README.md
 ```
 
 [*Read more about the Git `stripspace` command.*](http://git-scm.com/docs/git-stripspace)
-
-### SSH keys
-
-You can get a list of public ssh keys in plain text format by visiting:
-
-```
-https://github.com/{user}.keys
-```
-
-e.g. [https://github.com/tiimgreen.keys](https://github.com/tiimgreen.keys)
-
-[*Read more about accessing public ssh keys.*](https://changelog.com/github-exposes-public-ssh-keys-for-its-users/)
 
 ### Checking out Pull Requests
 


### PR DESCRIPTION
The 'SSH Keys' section talks about GitHub, not about Git.
