### PR TITLE
Fix mistake in Closing Issues via Commit Messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ https://github.com/rails/rails/blob/master/activemodel/lib/active_model.rb#L53-L
 ![Line Highlighting](http://i.imgur.com/8AhjrCz.png)
 
 ### Closing Issues via Commit Messages
-If a particular commit fixes an issue, any of the keywords `fix/fixes/fixed`, `close/closes/closed` or `resolve/resolves/resolved`, followed by the issue number, will close the issue once it is committed to the master branch.
+If a particular commit fixes an issue, any of the keywords `fix/fixes/fixed`, `close/closes/closed` or `resolve/resolves/resolved`, followed by the issue number, will close the issue once it is committed to the repository's default branch.
 
 ```bash
 $ git commit -m "Fix screwup, fixes #12"


### PR DESCRIPTION
The issue will be closed as soon as the commit is committed to the **repository's default branch**, not the master branch. I noticed this because we're using a different default branch for one of our projects.