### PR TITLE
Fix failures because of wrongly detected links on the ko readme

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_script:
   - gem install awesome_bot
 
 script:
-  - wl=https://github.com/rails/rails/compare/master@,http://git.io/abc123,https://github.com/..,youtube,chrome.google.com/webstore,https://github.com/mathiasbynens/dotfiles/blob/master/.gitconfig*,https://github.com/user/repo/compare/,vimeo
+  - wl=https://github.com/rails/rails/compare/master@,http://git.io/abc123,https://github.com/..,youtube,chrome.google.com/webstore,https://github.com/mathiasbynens/dotfiles/blob/master/.gitconfig*,https://github.com/user/repo/compare/,vimeo,http://confreaks.tv/videos/aloharuby2012-git-and-github-secrets
   - awesome_bot README.md       --allow-dupe --allow-redirect --white-list $wl
   - awesome_bot README.ko.md    --allow-dupe --allow-redirect --white-list $wl
   - awesome_bot README.ja.md    --allow-dupe --allow-redirect --white-list $wl

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,6 +1,6 @@
 # GitHub 치트 시트 [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
 
-Git과 GitHub에서 꽤 유용하지만 숨겨져 있는 기능들에 대해 다룹니다. 이 치트 시트는 [Zach Holman](https://github.com/holman)이 Aloha Ruby Conference 2012에서 발표한 [Git과 GitHub의 비밀들](http://confreaks.tv/videos/aloharuby2012-git-and-github-secrets)([슬라이드](https://speakerdeck.com/holman/git-and-github-secrets))과 WDCNZ 2013에서 발표한 [Git과 GitHub에 대한 더 많은 비밀들](https://vimeo.com/72955426)([슬라이드](https://speakerdeck.com/holman/more-git-and-github-secrets))에서 영감을 받아 작성되었습니다.
+Git과 GitHub에서 꽤 유용하지만 숨겨져 있는 기능들에 대해 다룹니다. 이 치트 시트는 [Zach Holman](https://github.com/holman)이 Aloha Ruby Conference 2012에서 발표한 [Git과 GitHub의 비밀들](http://confreaks.tv/videos/aloharuby2012-git-and-github-secrets) ([슬라이드](https://speakerdeck.com/holman/git-and-github-secrets))과 WDCNZ 2013에서 발표한 [Git과 GitHub에 대한 더 많은 비밀들](https://vimeo.com/72955426) ([슬라이드](https://speakerdeck.com/holman/more-git-and-github-secrets))에서 영감을 받아 작성되었습니다.
 
 *단축주소: [`http://git.io/sheet`](http://git.io/sheet)*
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,6 +1,6 @@
 # GitHub 치트 시트 [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
 
-Git과 GitHub에서 꽤 유용하지만 숨겨져 있는 기능들에 대해 다룹니다. 이 치트 시트는 [Zach Holman](https://github.com/holman)이 Aloha Ruby Conference 2012에서 발표한 [Git과 GitHub의 비밀들](http://confreaks.tv/videos/aloharuby2012-git-and-github-secrets) ([슬라이드](https://speakerdeck.com/holman/git-and-github-secrets))과 WDCNZ 2013에서 발표한 [Git과 GitHub에 대한 더 많은 비밀들](https://vimeo.com/72955426) ([슬라이드](https://speakerdeck.com/holman/more-git-and-github-secrets))에서 영감을 받아 작성되었습니다.
+Git과 GitHub에서 꽤 유용하지만 숨겨져 있는 기능들에 대해 다룹니다. 이 치트 시트는 [Zach Holman](https://github.com/holman)이 Aloha Ruby Conference 2012에서 발표한 [Git과 GitHub의 비밀들](http://confreaks.tv/videos/aloharuby2012-git-and-github-secrets)([슬라이드](https://speakerdeck.com/holman/git-and-github-secrets))과 WDCNZ 2013에서 발표한 [Git과 GitHub에 대한 더 많은 비밀들](https://vimeo.com/72955426)([슬라이드](https://speakerdeck.com/holman/more-git-and-github-secrets))에서 영감을 받아 작성되었습니다.
 
 *단축주소: [`http://git.io/sheet`](http://git.io/sheet)*
 


### PR DESCRIPTION
This should fix a couple of links that where not properly detected and made the CI fail. Hopefully introducing those spaces is not wrong on Korean...