### PR TITLE
update description of search box

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ When on a repository page, keyboard shortcuts allow you to navigate easily.
 
  - Pressing `t` will bring up a file explorer.
  - Pressing `w` will bring up the branch selector.
- - Pressing `s` will focus the search field for the current repository. Pressing Backspace to delete the “This repository” pill changes the field to search all of GitHub.
+ - Pressing `s` will focus the search field for the current repository. Pressing ↓ to select the “All GitHub” option changes the field to search all of GitHub.
  - Pressing `l` will edit labels on existing Issues.
  - Pressing `y` **when looking at a file** (e.g., `https://github.com/tiimgreen/github-cheat-sheet/blob/master/README.md`) will change your URL to one which, in effect, freezes the page you are looking at. If this code changes, you will still be able to see what you saw at that current time.
 


### PR DESCRIPTION
The search box doesn't have filter pills anymore. Now there are selectable options in the drop down menu list below instead:
![image](https://user-images.githubusercontent.com/11715448/73610743-09099a00-45db-11ea-83c8-4d304b3993d4.png)

## Alternatively you could also just leave out the sentence at all, since the behaviour is straight forward.