### PR TITLE
Remove Git.io (fix #223)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -16,7 +16,6 @@
     - [ブランチ同士の比較](#%E3%83%96%E3%83%A9%E3%83%B3%E3%83%81%E5%90%8C%E5%A3%AB%E3%81%AE%E6%AF%94%E8%BC%83)
     - [フォークされたリポジトリ間でのブランチ比較](#%E3%83%95%E3%82%A9%E3%83%BC%E3%82%AF%E3%81%95%E3%82%8C%E3%81%9F%E3%83%AA%E3%83%9D%E3%82%B8%E3%83%88%E3%83%AA%E9%96%93%E3%81%A7%E3%81%AE%E3%83%96%E3%83%A9%E3%83%B3%E3%83%81%E6%AF%94%E8%BC%83)
   - [Gists](#gists)
-  - [Git.io](#gitio)
   - [キーボード・ショートカット](#%E3%82%AD%E3%83%BC%E3%83%9C%E3%83%BC%E3%83%89%E3%82%B7%E3%83%A7%E3%83%BC%E3%83%88%E3%82%AB%E3%83%83%E3%83%88)
   - [コードの指定行の強調](#%E3%82%B3%E3%83%BC%E3%83%89%E3%81%AE%E6%8C%87%E5%AE%9A%E8%A1%8C%E3%81%AE%E5%BC%B7%E8%AA%BF)
   - [コミットからissueを閉じる](#%E3%82%B3%E3%83%9F%E3%83%83%E3%83%88%E3%81%8B%E3%82%89issue%E3%82%92%E9%96%89%E3%81%98%E3%82%8B)
@@ -202,25 +201,6 @@ Password for 'https://tiimgreen@gist.github.com':
 しかしながら、Gistではディレクトリーがサポートされていない。全てのファイルはリポジトリーのルートに置かれている必要がある。
 
 [*Gistの作成についてもっと詳しく*](https://help.github.com/articles/creating-gists)
-
-### Git.io
-[Git.io](http://git.io)はGitHubの提供するGitHub専用のシンプルな短縮URLサービスだ。
-
-![Git.io](http://i.imgur.com/6JUfbcG.png?1)
-
-cURLを使って利用することができる:
-
-```bash
-$ curl -i http://git.io -F "url=https://github.com/..."
-HTTP/1.1 201 Created
-Location: http://git.io/abc123
-
-$ curl -i http://git.io/abc123
-HTTP/1.1 302 Found
-Location: https://github.com/...
-```
-
-[*Git.ioについてもっと詳しく*](https://github.com/blog/985-git-io-github-url-shortener)
 
 ### キーボード・ショートカット
 リポジトリをブラウザーで開いている時は、ショートカットを利用して様々な機能ヘ簡単にアクセスできるようになっている。

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,6 @@ Git과 GitHub에서 꽤 유용하지만 숨겨져 있는 기능들에 대해 다
     - [Comparing Branches](#comparing-branches)
     - [Compare Branches across Forked Repositories](#compare-branches-across-forked-repositories)
   - [Gists](#gists)
-  - [Git.io](#gitio)
   - [Keyboard Shortcuts](#keyboard-shortcuts)
   - [Line Highlighting in Repositories](#line-highlighting-in-repositories)
   - [Closing Issues via Commit Messages](#closing-issues-via-commit-messages)
@@ -217,26 +216,6 @@ Password for 'https://tiimgreen@gist.github.com':
 
 하지만, Gists는 디렉터리를 지원하지 않습니다. 모든 파일은 저장소의 루트에 넣을 필요가 있습니다.
 [*Gist를 만드는 법에 대해 더 읽어보세요.*](https://help.github.com/articles/creating-gists)
-
-### Git.io
-
-[Git.io](http://git.io)는 GitHub를 위한 간단한 URL 단축기입니다.
-
-![Git.io](http://i.imgur.com/6JUfbcG.png?1)
-
-Curl으로 순수 HTTP를 통해 사용하실 수도 있습니다.
-
-```bash
-$ curl -i http://git.io -F "url=https://github.com/..."
-HTTP/1.1 201 Created
-Location: http://git.io/abc123
-
-$ curl -i http://git.io/abc123
-HTTP/1.1 302 Found
-Location: https://github.com/...
-```
-
-[*Git.io에 대해 더 읽어 보세요.*](https://github.com/blog/985-git-io-github-url-shortener)
 
 ### Keyboard Shortcuts
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ GitHub Cheat Sheet is sponsored by [Snapshot: create interactive professional-qu
       - [Comparing Branches](#comparing-branches)
       - [Compare Branches across Forked Repositories](#compare-branches-across-forked-repositories)
     - [Gists](#gists)
-    - [Git.io](#gitio)
     - [Keyboard Shortcuts](#keyboard-shortcuts)
     - [Line Highlighting in Repositories](#line-highlighting-in-repositories)
     - [Closing Issues via Commit Messages](#closing-issues-via-commit-messages)
@@ -214,25 +213,6 @@ Password for 'https://tiimgreen@gist.github.com':
 
 However, Gists do not support directories. All files need to be added to the repository root.
 [*Read more about creating Gists.*](https://help.github.com/articles/creating-gists/)
-
-### Git.io
-[Git.io](http://git.io) is a simple URL shortener for GitHub.
-
-![Git.io](http://i.imgur.com/6JUfbcG.png?1)
-
-You can also use it via pure HTTP using Curl:
-
-```bash
-$ curl -i http://git.io -F "url=https://github.com/..."
-HTTP/1.1 201 Created
-Location: http://git.io/abc123
-
-$ curl -i http://git.io/abc123
-HTTP/1.1 302 Found
-Location: https://github.com/...
-```
-
-[*Read more about Git.io.*](https://github.com/blog/985-git-io-github-url-shortener)
 
 ### Keyboard Shortcuts
 When on a repository page, keyboard shortcuts allow you to navigate easily.

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -14,7 +14,6 @@ Git 和 Github 秘籍，灵感来自于 [Zach Holman](https://github.com/holman)
       - [比较分支](#比较分支)
       - [比较不同派生库的分支](#比较不同派生库的分支)
     - [Gists](#gists)
-    - [Git.io](#gitio)
     - [键盘快捷键](#键盘快捷键)
     - [整行高亮](#整行高亮)
     - [用 Commit 信息关闭 Issue](#用-commit-信息关闭-issue)
@@ -200,25 +199,6 @@ Password for 'https://tiimgreen@gist.github.com':
 
 但是， Gists 不支持目录。所有文件都必须添加在仓库的根目录下。
 [*进一步了解如何创建 Gists.*](https://help.github.com/articles/creating-gists)
-
-### Git.io
-[Git.io](http://git.io)是 Github 的短网址服务。
-
-![Git.io](http://i.imgur.com/6JUfbcG.png?1)
-
-你可以通过 Curl 命令以普通 HTTP 协议使用它：
-
-```bash
-$ curl -i http://git.io -F "url=https://github.com/..."
-HTTP/1.1 201 Created
-Location: http://git.io/abc123
-
-$ curl -i http://git.io/abc123
-HTTP/1.1 302 Found
-Location: https://github.com/...
-```
-
-[*进一步了解 Git.io.*](https://github.com/blog/985-git-io-github-url-shortener)
 
 ### 键盘快捷键
 

--- a/README.zh-tw.md
+++ b/README.zh-tw.md
@@ -14,7 +14,6 @@ Git 和 Github 秘笈，靈感來自於 [Zach Holman](https://github.com/holman)
       - [比較分支](#比較分支)
       - [比較不同派生庫的分支](#比較不同派生庫的分支)
     - [Gists](#gists)
-    - [Git.io](#gitio)
     - [鍵盤快捷鍵](#鍵盤快捷鍵)
     - [整行高亮](#整行高亮)
     - [用 Commit 訊息關閉 Issue](#用-commit-訊息關閉-issue)
@@ -202,25 +201,6 @@ Password for 'https://tiimgreen@gist.github.com':
 
 但是， Gists 不支持目錄。所有文件都必須添加在倉庫的根目錄下。
 [*進一步了解如何建立 Gists.*](https://help.github.com/articles/creating-gists)
-
-### Git.io
-[Git.io](http://git.io)是 Github 的短網址服務。
-
-![Git.io](http://i.imgur.com/6JUfbcG.png?1)
-
-你可以通過 Curl 命令以普通 HTTP 協議使用它：
-
-```bash
-$ curl -i http://git.io -F "url=https://github.com/..."
-HTTP/1.1 201 Created
-Location: http://git.io/abc123
-
-$ curl -i http://git.io/abc123
-HTTP/1.1 302 Found
-Location: https://github.com/...
-```
-
-[*進一步了解 Git.io.*](https://github.com/blog/985-git-io-github-url-shortener)
 
 ### 鍵盤快捷鍵
 


### PR DESCRIPTION
Prev PR: #224

Blog, related to change: https://github.blog/changelog/2022-04-25-git-io-deprecation/