### PR TITLE
Fix typo in Git LFS article title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1082,4 +1082,4 @@ $ git config --global color.ui 1
 | Title | Link |
 | ----- | ---- |
 | GitHub Flow  | http://scottchacon.com/2011/08/31/github-flow.html |
-| Migrating to Git Large File Storate (Git LFS) | http://vooban.com/en/tips-articles-geek-stuff/migrating-to-git-lfs-for-developing-deep-learning-applications-with-large-files/ |
+| Migrating to Git Large File Storage (Git LFS) | http://vooban.com/en/tips-articles-geek-stuff/migrating-to-git-lfs-for-developing-deep-learning-applications-with-large-files/ |


### PR DESCRIPTION
Fixed typo: "Storate" changed to "Storage" in Git Articles section